### PR TITLE
IdentityServerのAPIを保護する

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 各ステップでタグ付けしています。
 Zenn、Qiita に投稿した以下の記事と対応しています。
 
-https://zenn.dev/tatsuteb/articles/751459a328fc80
+https://zenn.dev/tatsuteb/articles/751459a328fc80  
 https://qiita.com/tatsuteb/items/573e42ce3e47daf0d392
 
 ## 構成

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # SSO-using-IdentityServer4
 ステップバイステップでIdentityServer4を導入してシングルサインオンを実現する
 
+各ステップでタグ付けしています。
+Zenn、Qiita に投稿した以下の記事と対応しています。
+
+https://zenn.dev/tatsuteb/articles/751459a328fc80
+https://qiita.com/tatsuteb/items/573e42ce3e47daf0d392
+
 ## 構成
 
 | 種類 | ポート |

--- a/SSOusingIdentityServer4/IdentityServer/Config.cs
+++ b/SSOusingIdentityServer4/IdentityServer/Config.cs
@@ -16,7 +16,8 @@ namespace IdentityServer
         public static IEnumerable<ApiScope> ApiScopes =>
             new List<ApiScope>
             {
-                new ApiScope("api1", "Protected API sample.")
+                new ApiScope("api1", "Protected API sample."),
+                new ApiScope(IdentityServerConstants.LocalApi.ScopeName)
             };
 
         public static IEnumerable<Client> Clients =>
@@ -43,7 +44,8 @@ namespace IdentityServer
                     {
                         IdentityServerConstants.StandardScopes.OpenId,
                         IdentityServerConstants.StandardScopes.Profile,
-                        "api1"
+                        "api1",
+                        IdentityServerConstants.LocalApi.ScopeName
                     }
                 }
             };

--- a/SSOusingIdentityServer4/IdentityServer/Controllers/MessageController.cs
+++ b/SSOusingIdentityServer4/IdentityServer/Controllers/MessageController.cs
@@ -1,0 +1,18 @@
+﻿using IdentityServer4;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IdentityServer.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class MessageController : ControllerBase
+    {
+        [Authorize(IdentityServerConstants.LocalApi.PolicyName)]
+        [HttpGet("protected")]
+        public string GetMessageFromProtectedApi()
+        {
+            return "Secret from IdentityServer.";
+        }
+    }
+}

--- a/SSOusingIdentityServer4/IdentityServer/Startup.cs
+++ b/SSOusingIdentityServer4/IdentityServer/Startup.cs
@@ -60,6 +60,19 @@ namespace IdentityServer
                 builder.AddDeveloperSigningCredential();
             }
 
+            services.AddLocalApiAuthentication();
+
+            services.AddCors(options =>
+            {
+                options.AddPolicy(name: "default",
+                    corsPolicyBuilder =>
+                    {
+                        corsPolicyBuilder.WithOrigins(new []{ "https://localhost:7001" })
+                            .AllowAnyHeader()
+                            .AllowAnyMethod();
+                    });
+            });
+
             // ログイン画面等のパスを変えたい場合はここで指定できる
             // services.ConfigureApplicationCookie(config =>
             // {
@@ -79,6 +92,8 @@ namespace IdentityServer
             }
 
             app.UseRouting();
+            
+            app.UseCors("default");
 
             // UseIdentityServer() の中で、UseAuthentication() も呼び出される
             app.UseIdentityServer();

--- a/SSOusingIdentityServer4/WebClient/ClientApp/src/components/Home/index.tsx
+++ b/SSOusingIdentityServer4/WebClient/ClientApp/src/components/Home/index.tsx
@@ -10,6 +10,7 @@ const Home = (props: Props) => {
 
   const [message, setMessage] = useState('');
   const [messageFromProtectedApi, setMessageFromProtectedApi] = useState('');
+  const [messageFromIdServerProtectedApi, setMessageFromIdServerProtectedApi] = useState('');
   
   const onGetMessageHandler = async () => {
     try {
@@ -29,6 +30,17 @@ const Home = (props: Props) => {
     }
   };
 
+  const onGetMessageFromIdServerProtectedApiHandler = async () => {
+    try {
+      const response = await axios.get('/api/message/protected', {
+        baseURL: 'https://localhost:5001'
+      });
+      setMessageFromIdServerProtectedApi(response.data);
+    } catch (e) {
+      props.addErrorMessage(`失敗：GET https://localhost:5001/api/message/protected\n${e.message}`);
+    }
+  };
+
   return (
     <div>
       <h2>Home</h2>
@@ -43,6 +55,12 @@ const Home = (props: Props) => {
         <div>URI: <a href='https://localhost:6001/api/message/protected'>https://localhost:6001/api/message/protected</a></div>
         <div>Message: <span style={{ color: 'green', fontWeight: 'bold' }}>{messageFromProtectedApi}</span></div>
         <button onClick={onGetMessageFromProtectedApiHandler}>保護されたAPIからメッセージを取得</button>
+      </div>
+
+      <div style={{ marginTop: '20px' }}>
+        <div>URI: <a href='https://localhost:5001/api/message/protected'>https://localhost:5001/api/message/protected</a></div>
+        <div>Message: <span style={{ color: 'green', fontWeight: 'bold' }}>{messageFromIdServerProtectedApi}</span></div>
+        <button onClick={onGetMessageFromIdServerProtectedApiHandler}>IdentityServerの保護されたAPIからメッセージを取得</button>
       </div>
     </div>
   );

--- a/SSOusingIdentityServer4/WebClient/ClientApp/src/components/commons/UserAuthProvider.tsx
+++ b/SSOusingIdentityServer4/WebClient/ClientApp/src/components/commons/UserAuthProvider.tsx
@@ -20,7 +20,7 @@ const useUserAuth = (): UserAuth => {
     client_id: 'js',
     redirect_uri: 'https://localhost:7001/callback',
     response_type: 'code',
-    scope: 'openid profile offline_access api1',
+    scope: 'openid profile offline_access api1 IdentityServerApi',
     post_logout_redirect_uri: 'https://localhost:7001',
     automaticSilentRenew: true,
     silentRequestTimeout: 3000,


### PR DESCRIPTION
ウェブクライアントからIdentityServerに用意したAPI（https://localhost:5001/api/message/protected）よ呼び出す